### PR TITLE
CI: split gates + Codecov; docs: AGENTS.md defaults

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,35 @@
+name: CI
+
+on:
+  push:
+    branches: ["**"]
+  pull_request:
+    branches: ["**"]
+
+jobs:
+  build-and-test:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Use Node.js 20
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: 'npm'
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Typecheck
+        run: npm run typecheck
+
+      - name: Lint
+        run: npm run lint
+
+      - name: Unit tests (Jest)
+        env:
+          CI: true
+        run: npm run test:unit
+

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,44 +7,53 @@ on:
     branches: ["**"]
 
 jobs:
-  build-and-test:
+  gate-typecheck:
+    name: gate-typecheck
     runs-on: ubuntu-latest
     steps:
-      - name: Checkout
-        uses: actions/checkout@v4
+      - uses: actions/checkout@v4
         with:
           fetch-depth: 0
-
-      - name: Use Node.js 20
-        uses: actions/setup-node@v4
+      - uses: actions/setup-node@v4
         with:
           node-version: '20'
           cache: 'npm'
+      - run: npm ci
+      - run: npm run gate:typecheck
 
-      - name: Install dependencies
-        run: npm ci
+  gate-lint:
+    name: gate-lint
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: 'npm'
+      - run: npm ci
+      - run: npm run gate:lint
 
+  gate-unit:
+    name: gate-unit
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: 'npm'
+      - run: npm ci
       - name: Set BASE_REF for PRs
         if: ${{ github.event_name == 'pull_request' }}
         run: echo "BASE_REF=${{ github.event.pull_request.base.sha }}" >> $GITHUB_ENV
-
-      - name: Gate - typecheck
-        run: npm run gate:typecheck
-
-      - name: Gate - lint
-        run: npm run gate:lint
-
-      - name: Gate - unit (changed-lines coverage)
+      - name: Run unit gate (Vitest)
         env:
           CI: true
         run: npm run gate:unit
-
-      - name: Unit tests (Jest)
-        if: ${{ always() }}
-        env:
-          CI: true
-        run: npm run test:unit
-
       - name: Upload gate artifacts
         if: ${{ always() }}
         uses: actions/upload-artifact@v4
@@ -53,8 +62,7 @@ jobs:
           path: gate-artifacts
           if-no-files-found: ignore
           retention-days: 7
-
-      - name: Upload coverage
+      - name: Upload coverage (artifact)
         if: ${{ always() }}
         uses: actions/upload-artifact@v4
         with:
@@ -62,3 +70,47 @@ jobs:
           path: coverage
           if-no-files-found: ignore
           retention-days: 7
+
+  jest-unit:
+    name: jest-unit
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: 'npm'
+      - run: npm ci
+      - name: Run Jest unit tests
+        env:
+          CI: true
+        run: npm run test:unit
+
+  codecov:
+    name: codecov
+    needs: [gate-unit]
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: 'npm'
+      - run: npm ci
+      - name: Re-run vitest to ensure coverage exists (no-op if cached)
+        env:
+          CI: true
+        run: npm run gate:unit || true
+      - name: Upload to Codecov
+        uses: codecov/codecov-action@v4
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}
+          files: ./coverage/coverage-final.json
+          flags: unit
+          name: codecov
+          fail_ci_if_error: true
+          verbose: false

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,6 +12,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
 
       - name: Use Node.js 20
         uses: actions/setup-node@v4
@@ -22,14 +24,41 @@ jobs:
       - name: Install dependencies
         run: npm ci
 
-      - name: Typecheck
-        run: npm run typecheck
+      - name: Set BASE_REF for PRs
+        if: ${{ github.event_name == 'pull_request' }}
+        run: echo "BASE_REF=${{ github.event.pull_request.base.sha }}" >> $GITHUB_ENV
 
-      - name: Lint
-        run: npm run lint
+      - name: Gate - typecheck
+        run: npm run gate:typecheck
+
+      - name: Gate - lint
+        run: npm run gate:lint
+
+      - name: Gate - unit (changed-lines coverage)
+        env:
+          CI: true
+        run: npm run gate:unit
 
       - name: Unit tests (Jest)
+        if: ${{ always() }}
         env:
           CI: true
         run: npm run test:unit
 
+      - name: Upload gate artifacts
+        if: ${{ always() }}
+        uses: actions/upload-artifact@v4
+        with:
+          name: gate-artifacts
+          path: gate-artifacts
+          if-no-files-found: ignore
+          retention-days: 7
+
+      - name: Upload coverage
+        if: ${{ always() }}
+        uses: actions/upload-artifact@v4
+        with:
+          name: coverage
+          path: coverage
+          if-no-files-found: ignore
+          retention-days: 7

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -2,31 +2,92 @@
 
 Scope: Applies to the entire repository.
 
-Principles
-- Keep edits minimal and scoped to the task; avoid unrelated refactors.
-- Prefer clarity and reversibility; explain why when offering tradeoffs.
-- Use Node 20 and existing npm scripts; no new tooling without confirmation.
+Core Principles
+- Preserve existing functionality; never regress working features while changing code.
+- Make minimal, targeted changes; avoid unrelated refactors.
+- Prioritize reliability and robustness over cleverness; default to conservative approaches.
+- Explain trade-offs when proposing options; prefer reversible steps.
+- Use Node.js 20 LTS and existing npm scripts; do not add tooling without confirmation.
 
-Planning & Process
-- Use the plan tool for any task with more than one step; keep exactly one step in_progress.
-- Share brief progress notes before long-running actions.
-- Ask before destructive actions (rm/reset/rewrite history), DB schema changes, or network installs.
+Planning & Workflow
+- Use the plan tool for any task > 1 step; keep exactly one step in_progress.
+- Share concise progress notes before long-running actions.
+- Ask before destructive actions (rm/reset/history rewrite), DB schema changes, or network installs.
+- Commits: Conventional Commits; branches: `feat/*`, `fix/*`, `chore/*`.
 
-Code & Tests
-- TypeScript style as in repo; no license headers.
-- Do not remove tests; keep unit tests network-free (use mocks in tests/setup.ts).
-- Keep changed-lines coverage gate >= 0.90 via `scripts/runGate.js`.
+Technology & Stack Preferences
+- Language: Prefer TypeScript over JavaScript.
+- Testing:
+  - Unit: Jest under `tests/**`.
+  - Unit gate: Vitest changed-lines coverage via `scripts/runGate.js`.
+  - E2E: Playwright for end-to-end when UI/flows are affected. Run Playwright locally/CI when available; if browsers or services are missing, document exact steps to run and do not block delivery.
+- Linting/Style: Use the repo’s ESLint config. Only use Prettier if already configured.
+- Package manager: npm; commit lockfile.
 
-Shell & Files
-- Prefer `rg` for search; read files in chunks ≤ 250 lines.
-- Follow existing layout: API in `src/api`, worker in `src/worker`, UI in `src/ui`.
+Quality Standards
+- Test coverage: aim for 90%+ unit; enforce changed-lines coverage ≥ 0.90 in gate.
+- Performance targets (guidance): API p95 < 200ms; DB query p95 < 100ms.
+- Security: follow OWASP Top 10 practices; perform dependency audits; never store secrets in code.
+- Accessibility (UI): prefer semantic HTML and ARIA; target WCAG 2.1 AA when adding UI.
+- Documentation: add focused TSDoc/JSDoc for new/changed public APIs.
 
-CI & Branching
-- CI checks are split by gate: typecheck, lint, gate-unit (Vitest), jest-unit.
-- Codecov is enabled; keep PR comments off/minimal; rely on status checks.
-- Branches: `feat/*`, `fix/*`, `chore/*`. Use Conventional Commits.
+Development Process
+- Code changes: incremental and tested over large rewrites.
+- Error handling: comprehensive with structured logging; avoid leaking sensitive data.
+- Observability: use structured logs (correlation IDs where relevant); keep/extend health checks.
+- Security-first: parameterized queries; do not commit credentials; use env/secret stores.
+
+Framework-Specific Guidance
+- UI (EJS now; React if introduced later):
+  - Use semantic HTML, ARIA labels, and error boundaries (React) as applicable.
+  - Optimize for Core Web Vitals if/when using React.
+  - Implement sensible state management if introducing React.
+- Node.js/Backend:
+  - Prefer async/await; implement middleware patterns in Express routes.
+  - Use structured logging with request IDs; implement health checks and graceful shutdown.
+  - Use DB connection pooling.
+- Database:
+  - Use parameterized queries; add indexes thoughtfully.
+  - Apply schema changes via migrations; monitor query performance.
+
+AI Behavior Preferences
+- Explanations: briefly justify technical decisions and list trade-offs.
+- Alternatives: suggest viable options when appropriate.
+- Learning: add short educational context for new patterns when helpful.
+- Uncertainty: call out uncertainty and propose verification steps.
+
+Command & Repo Usage
+- Prefer `rg` for search; read files in ≤ 250-line chunks.
+- Scope commands to changed/related files; use `--all` only when necessary.
+- Prefer incremental improvements over rewrites; validate changes with appropriate tests.
+
+CI, Gates, and Coverage
+- CI checks are split by gate: `gate-typecheck`, `gate-lint`, `gate-unit` (Vitest), and `jest-unit`.
+- Codecov is enabled; keep PR comments minimal/off; rely on status checks.
+- Maintain the changed-lines coverage gate at ≥ 0.90.
+
+Monitoring & Security
+- Structured logs with context; collect basic performance/error metrics where applicable.
+- Input validation and output encoding for user content.
+- Authentication/authorization checks where relevant; secure session/CSRF if adding forms.
+- Secrets managed via environment/secret stores; support rotation.
+- Audit logging for security-relevant events where applicable.
+
+Documentation Standards
+- Keep README accurate for setup and usage.
+- Document API endpoints with examples when changed.
+- Record significant design choices as lightweight ADRs when applicable.
+- Add inline comments for complex business logic.
+- Provide troubleshooting notes for common local issues.
+
+Compliance & Safety (as applicable)
+- Avoid leaking sensitive information in errors/logs.
+- Prefer HTTPS and rate limiting in deploy contexts.
+- Maintain audit trails for compliance-sensitive changes.
 
 Local Running
 - Supabase Local for DB/Auth/Storage; Redis for queue.
 - Use provided npm scripts (e.g., `dev`, `gates`).
 
+Non-Negotiable
+- Always preserve existing functionality and fix the specific issue without breaking features.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,32 @@
+# Agent Guidelines for NOFX Local Starter
+
+Scope: Applies to the entire repository.
+
+Principles
+- Keep edits minimal and scoped to the task; avoid unrelated refactors.
+- Prefer clarity and reversibility; explain why when offering tradeoffs.
+- Use Node 20 and existing npm scripts; no new tooling without confirmation.
+
+Planning & Process
+- Use the plan tool for any task with more than one step; keep exactly one step in_progress.
+- Share brief progress notes before long-running actions.
+- Ask before destructive actions (rm/reset/rewrite history), DB schema changes, or network installs.
+
+Code & Tests
+- TypeScript style as in repo; no license headers.
+- Do not remove tests; keep unit tests network-free (use mocks in tests/setup.ts).
+- Keep changed-lines coverage gate >= 0.90 via `scripts/runGate.js`.
+
+Shell & Files
+- Prefer `rg` for search; read files in chunks ≤ 250 lines.
+- Follow existing layout: API in `src/api`, worker in `src/worker`, UI in `src/ui`.
+
+CI & Branching
+- CI checks are split by gate: typecheck, lint, gate-unit (Vitest), jest-unit.
+- Codecov is enabled; keep PR comments off/minimal; rely on status checks.
+- Branches: `feat/*`, `fix/*`, `chore/*`. Use Conventional Commits.
+
+Local Running
+- Supabase Local for DB/Auth/Storage; Redis for queue.
+- Use provided npm scripts (e.g., `dev`, `gates`).
+

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,14 @@
+codecov:
+  require_ci_to_pass: true
+
+comment: false
+
+coverage:
+  status:
+    project:
+      default:
+        informational: true
+    patch:
+      default:
+        informational: true
+


### PR DESCRIPTION
This PR introduces split CI gates (typecheck, lint, gate-unit, jest-unit), adds Codecov upload with minimal noise, and documents development preferences in AGENTS.md.\n\n- CI now enforces changed-lines coverage and uploads artifacts/coverage\n- Branch protection updated to require each check and Codecov flag\n- AGENTS.md codifies conservative-change policy and testing strategy\n\nOnce merged, main will be protected by the new checks.\n